### PR TITLE
added function for scrolling item into view when necessary

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -9,6 +9,11 @@ simplete-suggestions {
 	background-color: #EEE;
 }
 
+simplete-suggestions ul {
+	max-height: 8rem;
+	overflow: auto;
+}
+
 simplete-form[aria-busy=true],
 simplete-suggestions[aria-busy=true] {
 	opacity: 0.2;

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-import { selectLast } from "./util";
+import { scrollIfNecessary, selectLast } from "./util";
 import { dispatchEvent } from "uitil/dom/events";
 import { find } from "uitil/dom";
 import bindMethods from "uitil/method_context";
@@ -84,6 +84,8 @@ export default class SimpleteSuggestions extends HTMLElement {
 			currentItem.setAttribute("aria-selected", "true");
 			this.selectItem(currentItem, true);
 		}
+
+		scrollIfNecessary(currentItem);
 	}
 
 	onConfirm(ev) {

--- a/src/util.js
+++ b/src/util.js
@@ -3,3 +3,21 @@ export function selectLast(node, selector) {
 	let { length } = nodes;
 	return length ? nodes[length - 1] : null;
 }
+
+// NB: only supports vertical scrolling
+export function scrollIfNecessary(node) {
+	let parentDimensions = node.parentElement.getBoundingClientRect();
+	let nodeDimensions = node.getBoundingClientRect();
+
+	let parentTop = parentDimensions.top;
+	let nodeTop = nodeDimensions.top;
+
+	if((nodeTop + nodeDimensions.height) >
+		(parentDimensions.top + parentDimensions.height)) {
+		// NB: uses boolean parameter because IE11 doesn't support object parameter
+		node.scrollIntoView(false);
+	} else if(nodeTop < parentTop) {
+		// NB: uses boolean parameter because IE11 doesn't support object parameter
+		node.scrollIntoView(true);
+	}
+}


### PR DESCRIPTION
This adds a utility function `scrollIfNecessary` which will determine
whether or not an element is currently visible within its parent
container, and if not, will use the `scrollIntoView` function to scroll
the element into view. Developers are still responsible for writing the
CSS necessary to activate a scrollable container for large result sets.

Tested in:
Chrome, Firefox, Edge, Safari, IE11 (with the help of many polyfills)