### PR TITLE
made tag name for root element configurable for simplete-suggestions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "simplete",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"description": "HTML-based autocompletion",
 	"author": "FND",
 	"license": "Apache-2.0",

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -6,6 +6,7 @@ import bindMethods from "uitil/method_context";
 
 export const TAG = "simplete-suggestions";
 const DEFAULTS = {
+	rootSelector: "simplete-form",
 	itemSelector: "li",
 	fieldSelector: "input[type=hidden]",
 	resultSelector: "a"
@@ -157,6 +158,7 @@ export default class SimpleteSuggestions extends HTMLElement {
 	}
 
 	get root() {
-		return this.closest("simplete-form");
+		let selector = this.getAttribute("root-selector") || DEFAULTS.rootSelector;
+		return this.closest(selector);
 	}
 }


### PR DESCRIPTION
There may be instances where we want to reuse the simplete-suggestions
custom element but provide a different implementation for the simplete
form with some custom behavior. This modifies the simplete suggestions
custom element to make the selector for the root element configurable to
decouple it from the `simplete-form` tag name.