### PR TITLE
Fix scroll if necessary bug

### DIFF
--- a/demo/servers/languages.js
+++ b/demo/servers/languages.js
@@ -13,7 +13,7 @@ const LANGUAGES = [
 const WIKIPEDIA = "https://en.wikipedia.org/wiki/Special:Search?search=";
 
 let server = http.createServer((req, res) => {
-	let query = url.parse(req.url, true).query;
+	let query = url.parse(req.url, true).query; // eslint-disable-line node/no-deprecated-api
 	query = query && query.q;
 
 	let candidates = LANGUAGES;

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -84,9 +84,8 @@ export default class SimpleteSuggestions extends HTMLElement {
 		if(currentItem) {
 			currentItem.setAttribute("aria-selected", "true");
 			this.selectItem(currentItem, true);
+			scrollIfNecessary(currentItem);
 		}
-
-		scrollIfNecessary(currentItem);
 	}
 
 	onConfirm(ev) {


### PR DESCRIPTION
`scrollIfNecessary` throws an exception if the `currentItem` is null, so
this moves it into the `if(currentItem)` statement so that this
exception is no longer thrown.

Note: while committing, I realized that a line of code in the demo no longer works with the linter. I added the linter exception to this branch as well because I didn't think it needed a separate review, but if desired, I can open a separate Pull Request for that change.