### PR TITLE
improved accessibility by adding necessary aria roles and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Typing into that search field will result in a form submission (i.e. a
 Typically the server would respond with HTML like the following:
 
 ```html
-<ol>
+<ol aria-label="2 search suggestions">
     <li>
         <input type="hidden" value="foo">
         lorem ipsum
@@ -70,7 +70,7 @@ The server might also choose to respond with immediate results rather than query
 suggestions:
 
 ```html
-<ol>
+<ol aria-label="2 search suggestions">
     <li>
         <a href="http://example.org">example.org</a>
     </li>
@@ -82,7 +82,7 @@ suggestions:
 
 In fact, such HTML responses are not limited to any particular markup: The
 server is free to include multiple lists, contextual feedback messages or
-whatever seems appropriate (see (see [customization](#customization) below).
+whatever seems appropriate (see [customization](#customization) below).
 
 The `styles` directory contains some basic suggested CSS while `demo/demo.css`
 contains a rudimentary theme.
@@ -143,6 +143,20 @@ elements via selectors:
     </article>
 </simplete-form>
 ```
+
+
+### Accessibility
+
+Simplete will add the ARIA roles and attributes necessary in order for the
+autocomplete component to work with assistive technologies.
+
+While it is possible to [customize](#customization) the component with
+arbitrary HTML, we recommend using a semantic HTML list (`ol` or `ul`) with a
+corresponding
+[aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label),
+because we have performed screenreader tests for this markup
+(`aria-label` was necessary in order for the list of suggestions to be
+announced as a list in NVDA).
 
 
 Dependencies

--- a/demo/servers/languages.js
+++ b/demo/servers/languages.js
@@ -33,7 +33,7 @@ let server = http.createServer((req, res) => {
 		}).join("\n");
 		html = [
 			`<p>Results for '${query}':<p>\n`,
-			"<ul>",
+			`<ul aria-label="${candidates.length} search suggestion${candidates.length !== 1 ? "s" : ""}">`,
 			html,
 			"</ul>"
 		].join("\n");

--- a/demo/suggestions.html
+++ b/demo/suggestions.html
@@ -6,7 +6,7 @@
 
 	<h3>Query Suggestions</h3>
 	<p>You can refine your query using the following terms:</p>
-	<ol>
+	<ol aria-label="2 suggestions">
 		<li>
 			<button type="button" value="foo">Foo</button>
 		</li>
@@ -17,7 +17,7 @@
 
 	<h3>Websites</h3>
 	<p>Your query matched the following websites:</p>
-	<ol>
+	<ol aria-label="2 suggestions">
 		<li>
 			<a href="http://example.org">example.org</a>
 		</li>

--- a/src/form.js
+++ b/src/form.js
@@ -19,7 +19,7 @@ export default class SimpleteForm extends HTMLElement {
 	constructor(self) {
 		self = super(self);
 
-		bindMethods(self, "onInput", "onResponse");
+		bindMethods(self, "onInput", "onResponse", "onToggle");
 
 		return self;
 	}
@@ -33,11 +33,16 @@ export default class SimpleteForm extends HTMLElement {
 		let field = this.searchField;
 		field.setAttribute("autocomplete", "off");
 
+		field.setAttribute("role", "combobox");
+		field.setAttribute("aria-autocomplete", "list");
+		field.setAttribute("aria-expanded", "false");
+
 		let onQuery = debounce(this.queryDelay, this, this.onQuery);
 		this.addEventListener("input", onQuery);
 		this.addEventListener("change", onQuery);
 		this.addEventListener("simplete-suggestion-selection", this.onSelect);
 		field.addEventListener("keydown", this.onInput);
+		this.addEventListener("simplete-suggestion-toggle", this.onToggle);
 	}
 
 	onQuery(ev) {
@@ -106,13 +111,21 @@ export default class SimpleteForm extends HTMLElement {
 		}
 	}
 
+	onToggle(ev) {
+		let field = this.searchField;
+		field.setAttribute("aria-expanded", ev.detail.expanded ? "true" : "false");
+		field.removeAttribute("aria-activedescendant");
+	}
+
 	onSelect(ev) {
-		let { value, preview } = ev.detail;
+		let { id, value, preview } = ev.detail;
+		let field = this.searchField;
+		field.setAttribute("aria-activedescendant", id);
 		if(preview) {
 			this.navigating = true;
 		}
 		if(value) {
-			this.searchField.value = value;
+			field.value = value;
 			this.payload = this.serialize();
 		}
 
@@ -238,5 +251,9 @@ export default class SimpleteForm extends HTMLElement {
 
 	get cors() {
 		return this.hasAttribute("cors");
+	}
+
+	get suggestions() {
+		return this.querySelector(SUGGESTIONS_TAG);
 	}
 }


### PR DESCRIPTION
The necessary roles are as follows:

Combobox
--------

We need `role=combobox` on the search field to let assistive
technologies know that a dropdown will open while typing.
According to the ARIA Authoring Practices Guild for Combobox, this seems
like an appropriate role for the search field:
https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role

An alternative could be to set `aria-haspopup=listbox` on the search
field without the `combobox` role (a `combobox` always has a default
implicit `aria-haspopup=listbox` property).

The necessary ARIA attributes for the `combobox` are as follows:

* `aria-autocomplete` is set to `list` to make assistive technologies
  aware that there is autocomplete available in the form of a listbox
  https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete
* `aria-expanded` must be set to `false` when the popup is closed and
  set to `true` whenever it opens -- it should never be omitted because
  the presence of `aria-expanced=false` indicates to assistive
  technologies that there is something which can be expanded.
  https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded
* `aria-owns` is set to the `id` of the suggestions listbox to make the
  relationship clear between the combobox and listbox. This is necessary
  because it isn't possible to show the relationship via HTML DOM
  https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-owns
  `aria-owns` is supported for many screenreaders:
  https://a11ysupport.io/tech/aria/aria-owns_attribute
* `aria-activedescendant` is set whenever an option is selected in the
  listbox to indicate to assistive technologies which option is
  currently selected in the dropdown.

Listbox
-------

The `search-suggestions` element receives the `listbox` role to indicate
to assistive technologies that it is a popup containing a list of
options which can be selected via the arrows keys.

We also need to add a generated HTML id to the `search-suggestions`
element (if not already defined) so that it can be connected
to the combobox via `aria-owns`.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role

Option
------

Each item that is selectable within the dropdown must receive an
`option` role. Our options correspond with the elements selected by the
`itemSelector` defined for SimpleteSuggestions.

We also need to add a generated HTML id to each option (if not already
defined) so that it can be referenced via the `aria-activedescendant`
property of the combobox.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/option_role

For each option, we additionally need to define the following
attributes:

* `aria-selected` specifies whether or not the option is selected. Here
  we want to explicitly set `aria-selected=false` if it is not selected
  because that indicates to assistive technologies that the element is
  selectable.
  https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected