### PR TITLE
improved accessibility by removing focussable element from listbox

### DIFF
--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -12,6 +12,8 @@ const DEFAULTS = {
 	resultSelector: "a"
 };
 
+const FOCUSSABLE_ELEMENTS = "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1']";
+
 export default class SimpleteSuggestions extends HTMLElement {
 	// NB: `self` only required due to document-register-element polyfill
 	constructor(self) {
@@ -59,6 +61,9 @@ export default class SimpleteSuggestions extends HTMLElement {
 			let selector = container && container.getAttribute(attr);
 			this[prop] = selector || DEFAULTS[prop];
 		});
+
+		find(this, FOCUSSABLE_ELEMENTS).
+			forEach(el => el.setAttribute("tabindex", "-1"));
 	}
 
 	onCycle(ev) {


### PR DESCRIPTION
In a listbox popup, the items in the popup should only be accessible via
the arrow keys, and not via the TAB-Key. Anything else is not ideal for
accessibility or UX. A user may want to ignore the search suggestions,
and in this case, the next item in the TAB order should be the submit
button, not a list of options to select.

Additionally, by not removing the items from the TAB order, it is
possible to achieve constellations in the component which are
contradictory. For instance, if you type something into the search field
and three results come up, you can navigate with the arrow key to one of
the items. This is then highlighted and marked as selected both
visually and for assistive technologies, but then it is possible to use
the TAB key to navigate to a different link within the list. Upon
execution, the link which is selected with TAB is executed, even though
naively you would expect the item which the dropdown has marked as
selected to be executed.

Here is a screenshot illustrating the problem:
<img width="158" alt="A listbox with three items has one item visually selected with a yellow background and a different item selected with a blue focus ring" src="https://user-images.githubusercontent.com/1502724/188167654-860d8aa9-3e71-48bd-a191-d403cda46f78.png">
