### PR TITLE
improved accessibility of how the text field is filled during selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Typically the server would respond with HTML like the following:
 ```
 
 Selecting an item from that list will populate the search field with the
-corresponding value, which may subsequently be used to submit the surrounding
-form. (Note that keyboard-based submission of the surrounding form is only
-suppressed while navigating results.)
+corresponding value or the text content of the item, which may subsequently be
+used to submit the surrounding form. (Note that keyboard-based submission of
+the surrounding form is only suppressed while navigating results.)
 
 The server might also choose to respond with immediate results rather than query
 suggestions:
@@ -90,7 +90,6 @@ contains a rudimentary theme.
 Note that when a result is selected, a `"simplete-selection"` custom event is
 triggered on the associated `<simplete-form>` element. The respective value is
 accessible via `event.detail.value`.
-
 
 ### Customization
 
@@ -157,6 +156,14 @@ corresponding
 because we have performed screenreader tests for this markup
 (`aria-label` was necessary in order for the list of suggestions to be
 announced as a list in NVDA).
+
+We also recommend performing usability testing for your implementation of the
+component. The general expectation for a component like this is that selecting
+a result from the list of suggestions will behave in the same way as if that
+suggestion were entered into the search field and the form were submitted. If
+your links do not behave accordingly (e.g. if your search suggestions are links
+to a concrete page instead of to a list of search suggestions), you will need
+to find a way to communicate this to the user.
 
 
 Dependencies

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -141,7 +141,10 @@ export default class SimpleteSuggestions extends HTMLElement {
 		if(field) {
 			let { name, value } = field;
 			Object.assign(payload, { name, value });
+		} else if(node && node.textContent) {
+			Object.assign(payload, { value: node.textContent.trim() });
 		}
+
 		dispatchEvent(this.root, "simplete-suggestion-selection", payload);
 		return !!field;
 	}


### PR DESCRIPTION
This updates the component so that the search field will always be
populated whenever the user selects an option from within the listbox
popup. When no input field with a value is provided, the text content of
the item is used.

This is absolutely vital for accessibility because when using the
component with an assistive technology like a screenreader, the value of
the _search field_ will always be read out by the screenreader whenever
the selection in the popup changes -- that is how screenreaders expect
comboboxes to behave. Since this wasn't the case for the simplete
component, anyone using a screenreader would type in two characters into
the search field and then try to navigate the list of search suggestions
but would only hear those same two characters being read out every time
that something was suggested.

~~However, one thing that was noticed during the tests of this component
was that it should be possible for the user to decide to ignore the
options in the list and continue typing to complete their original
intended search string. This has been implemented in this commit by
checking if the user key typed is alphanumeric, and if so, restoring the
original query and aborting the simplete popup. It's possible that we
should extend the number of "normal user input" keys in the future to
recognize more than alphanumeric characters.~~