### PR TITLE
added simplete-status for announcing current status to assistive tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ However, it does rely on modern browser features which might have to be
 polyfilled:
 
 * custom elements — suggested polyfill:
-  [document-register-element](https://github.com/WebReflection/document-register-element)
+  [@ungap/custom-elements](https://github.com/ungap/custom-elements)
 * `fetch` — suggested polyfill: [whatwg-fetch](https://github.com/github/fetch)
   or [unfetch](https://github.com/developit/unfetch)
 * `CustomEvent`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ We start out with a fairly straightforward form:
 ```html
 <form action="/search" method="get">
     <simplete-form>
-        <input type="search" name="query">
+        <label>
+            search
+            <input type="search" name="query">
+        </label>
     </simplete-form>
 
     <button>search</button>
@@ -36,7 +39,10 @@ Or, if we want to target different resources:
 ```html
 <form action="/search" method="get">
     <simplete-form action="/search/suggestions" method="get">
-        <input type="search" name="query">
+        <label>
+            search
+            <input type="search" name="query">
+        </label>
     </simplete-form>
 
     <button>search</button>
@@ -116,9 +122,10 @@ accessible via `event.detail.value`.
 </simplete-form>
 ```
 
-Similarly, server responses may optionally use attributes to identify content
-elements via selectors:
+Similarly, server responses may optionally use attributes specify how the
+response should be interpreted:
 
+* `data-autocomplete-status` will be announced to assistive technologies
 * `data-item-selector` (defaults to `"li"`) identifies results
 * `data-field-selector` (defaults to `"input[type=hidden]"`) identifies fields
   whose `value` will be used for populating the search field
@@ -126,7 +133,8 @@ elements via selectors:
   immediate results
 
 ```html
-<section data-item-selector="article h3"
+<section data-autocomplete-status="2 search suggestions available"
+        data-item-selector="article h3"
         data-field-selector="button[type=button]"
         data-result-selector="button[type=submit]">
     <article>

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,7 +17,10 @@
 	<h2>Programming Languages</h2>
 	<form action="http://localhost:3003" method="get">
 		<simplete-form>
-			<input type="search" name="q">
+			<label>
+				search
+				<input type="search" name="q">
+			</label>
 		</simplete-form>
 
 		<button>search</button>
@@ -26,7 +29,10 @@
 	<h2>Mixed Content</h2>
 	<form action="results.html" method="get">
 		<simplete-form action="suggestions.html" method="get">
-			<input type="search" name="q">
+			<label>
+				search
+				<input type="search" name="q">
+			</label>
 			<label>
 				<input type="checkbox" name="case-sensitive" value="1">
 				case-sensitive

--- a/demo/index.html
+++ b/demo/index.html
@@ -36,7 +36,6 @@
 		<button>search</button>
 	</form>
 
-	<script src="../node_modules/document-register-element/build/document-register-element.js"></script>
 	<script src="../dist/simplete.js"></script>
 	<script>
 (function() {

--- a/demo/servers/languages.js
+++ b/demo/servers/languages.js
@@ -25,15 +25,20 @@ let server = http.createServer((req, res) => {
 
 	let html;
 	if(candidates.length === 0) {
-		html = `<p>No results for '${query}'.<p>`;
+		html = `
+<p data-autocomplete-status="0 search suggestions available">No results for '${query}'.<p>
+		`.trim();
 	} else {
+		let status = candidates.length === 1 ? "1 search suggestion available" :
+			`${candidates.length} search suggestions available`;
+
 		html = candidates.map(lang => {
 			let uri = WIKIPEDIA + encodeURIComponent(lang);
 			return `<li><a href="${uri}">${lang}</a></li>`;
 		}).join("\n");
 		html = [
 			"<div>",
-			`<p>Results for '${query}':<p>\n`,
+			`<p data-autocomplete-status="${status}">Results for '${query}':<p>\n`,
 			`<ul aria-label="${candidates.length} search suggestion${candidates.length !== 1 ? "s" : ""}">`,
 			html,
 			"</ul>",

--- a/demo/servers/languages.js
+++ b/demo/servers/languages.js
@@ -32,10 +32,12 @@ let server = http.createServer((req, res) => {
 			return `<li><a href="${uri}">${lang}</a></li>`;
 		}).join("\n");
 		html = [
+			"<div>",
 			`<p>Results for '${query}':<p>\n`,
 			`<ul aria-label="${candidates.length} search suggestion${candidates.length !== 1 ? "s" : ""}">`,
 			html,
-			"</ul>"
+			"</ul>",
+			"</div>"
 		].join("\n");
 	}
 

--- a/demo/suggestions.html
+++ b/demo/suggestions.html
@@ -1,4 +1,4 @@
-<div data-field-selector="button">
+<div data-field-selector="button" data-autocomplete-status="4 search suggestions available">
 	<p>
 		NB: The following list is static (to avoid setting up a server-side
 		application for this demo), which is why you'll always get the same results.

--- a/src/form.js
+++ b/src/form.js
@@ -1,5 +1,7 @@
 /* eslint-env browser */
 import { TAG as SUGGESTIONS_TAG } from "./suggestions";
+import { TAG as STATUS_TAG } from "./status";
+import { insertAfter } from "./util";
 import { serializeForm } from "uitil/dom/forms";
 import { dispatchEvent } from "uitil/dom/events";
 import bindMethods from "uitil/method_context";
@@ -22,12 +24,20 @@ export default class SimpleteForm extends HTMLElement {
 	}
 
 	connectedCallback() {
+		let field = this.searchField;
+
+		if(!this.querySelector(STATUS_TAG)) {
+			let status = document.createElement(STATUS_TAG);
+			let labelOrField = field.closest("label") || field;
+
+			insertAfter(status, labelOrField);
+		}
+
 		if(!this.querySelector(SUGGESTIONS_TAG)) { // guard against repeat initialization
 			let results = document.createElement(SUGGESTIONS_TAG);
 			this.appendChild(results);
 		}
 
-		let field = this.searchField;
 		field.setAttribute("autocomplete", "off");
 
 		field.setAttribute("role", "combobox");

--- a/src/form.js
+++ b/src/form.js
@@ -15,13 +15,10 @@ const DEFAULTS = {
 const RESET = {}; // poor man's `Symbol`
 
 export default class SimpleteForm extends HTMLElement {
-	// NB: `self` only required due to document-register-element polyfill
-	constructor(self) {
-		self = super(self);
+	constructor() {
+		super();
 
-		bindMethods(self, "onInput", "onResponse", "onToggle");
-
-		return self;
+		bindMethods(this, "onInput", "onResponse", "onToggle");
 	}
 
 	connectedCallback() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 /* eslint-env browser */
 import SimpleteForm, { TAG as FORM_TAG } from "./form";
 import SimpleteSuggestions, { TAG as SUGGESTIONS_TAG } from "./suggestions";
+import SimpleteStatus, { TAG as STATUS_TAG } from "./status";
 
 customElements.define(FORM_TAG, SimpleteForm);
 customElements.define(SUGGESTIONS_TAG, SimpleteSuggestions);
+customElements.define(STATUS_TAG, SimpleteStatus);

--- a/src/status.js
+++ b/src/status.js
@@ -1,0 +1,30 @@
+/* eslint-env browser */
+import bindMethods from "uitil/method_context";
+
+export const TAG = "simplete-status";
+const DEFAULTS = {
+	rootSelector: "simplete-form"
+};
+
+export default class SimpleteStatus extends HTMLElement {
+	constructor() {
+		super();
+
+		bindMethods(this, "onSuggestionStatus");
+	}
+
+	connectedCallback() {
+		this.setAttribute("aria-live", "assertive");
+
+		this.root.addEventListener("simplete-suggestion-status", this.onSuggestionStatus);
+	}
+
+	onSuggestionStatus(ev) {
+		this.textContent = ev.detail.status;
+	}
+
+	get root() {
+		let selector = this.getAttribute("root-selector") || DEFAULTS.rootSelector;
+		return this.closest(selector);
+	}
+}

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -60,6 +60,15 @@ export default class SimpleteSuggestions extends HTMLElement {
 			this[prop] = selector || DEFAULTS[prop];
 		});
 
+		let status = this.querySelector("[data-autocomplete-status]");
+		if(status) {
+			dispatchEvent(
+					this.root,
+					"simplete-suggestion-status",
+					{ status: status.getAttribute("data-autocomplete-status") || "" }
+			);
+		}
+
 		find(this, FOCUSSABLE_ELEMENTS).
 			forEach(el => el.setAttribute("tabindex", "-1"));
 

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -16,13 +16,10 @@ const DEFAULTS = {
 const FOCUSSABLE_ELEMENTS = "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1']";
 
 export default class SimpleteSuggestions extends HTMLElement {
-	// NB: `self` only required due to document-register-element polyfill
-	constructor(self) {
-		self = super(self);
+	constructor() {
+		super();
 
-		bindMethods(self, "onQuery", "onResults", "onCycle", "onConfirm", "onAbort");
-
-		return self;
+		bindMethods(this, "onQuery", "onResults", "onCycle", "onConfirm", "onAbort");
 	}
 
 	connectedCallback() {

--- a/src/util.js
+++ b/src/util.js
@@ -4,6 +4,10 @@ export function selectLast(node, selector) {
 	return length ? nodes[length - 1] : null;
 }
 
+export function insertAfter(newNode, referenceNode) {
+	referenceNode.parentNode.insertBefore(newNode, referenceNode.nextSibling);
+}
+
 // NB: only supports vertical scrolling
 export function scrollIfNecessary(node) {
 	let parentDimensions = node.parentElement.getBoundingClientRect();

--- a/styles/core.css
+++ b/styles/core.css
@@ -9,3 +9,27 @@ simplete-suggestions {
 simplete-suggestions:empty {
 	display: none;
 }
+
+/*
+Hide content visually:
+https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html#hiding-content-visually
+*/
+simplete-status {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	white-space: nowrap;
+}
+
+/*
+When the user does not have the focus within the search field, the status field
+should also be hidden for assistive technologies because it otherwise does not
+have any meaning.
+*/
+label:not(:focus-within) + simplete-status,
+input:not(:focus) + simplete-status {
+	display: none;
+}


### PR DESCRIPTION
This adds a simplete-status custom element which we can use as an ARIA
live region to announce to the user what the current status of the
component is (most often this will be something like: "5 search
suggestions available"). This may not be useful for every use case, so
this implements the simplete-status as an optional feature.

The actual autocomplete status is implemented by passing the current
status via the `data-autocomplete-status` in the result HTML. This means
that i18n must be implemented by the server.

One "bug" that was found in the first version of this implementation is
that the simplete-status element did not disappear by default when the
focus left the input field and was still available as a text node when
navigating through the DOM with assistive technologies. This also adds
some CSS `label:not(:focus-within) + simplete-status, input:not(:focus) + simplete-status { display: none; }` which will hide the status field
correctly if placed directly behind the search field in the HTML DOM.
The css works for both an `input` field wrapped in a `label` (at least
for browsers which support `:focus-within`), and for an `input` field
which is referenced by its label via its `for` attribute.