### PR TITLE
added simplete abort when the user continues typing 

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -100,7 +100,6 @@ export default class SimpleteForm extends HTMLElement {
 			// suppress form submission (only) while navigating results -
 			// otherwise let the browser's default behavior kick in
 			if(this.navigating) {
-				delete this.navigating;
 				dispatchEvent(this, "simplete-confirm"); // TODO: rename?
 				ev.preventDefault();
 			}
@@ -110,11 +109,15 @@ export default class SimpleteForm extends HTMLElement {
 		case 27: // Escape
 			if(this.query) { // restore original (pre-preview) input
 				this.searchField.value = this.query;
-				delete this.navigating;
 				dispatchEvent(this, "simplete-abort"); // TODO: rename?
 				ev.preventDefault();
 			}
 			break;
+		default:
+			if(this.query && this.navigating) { // restore original (pre-preview) input
+				this.searchField.value = this.query;
+				dispatchEvent(this, "simplete-abort"); // TODO: rename?
+			}
 		}
 	}
 
@@ -128,9 +131,6 @@ export default class SimpleteForm extends HTMLElement {
 		let { id, value, preview } = ev.detail;
 		let field = this.searchField;
 		field.setAttribute("aria-activedescendant", id);
-		if(preview) {
-			this.navigating = true;
-		}
 		if(value) {
 			field.value = value;
 			this.payload = this.serialize();
@@ -213,6 +213,10 @@ export default class SimpleteForm extends HTMLElement {
 
 	get blank() {
 		return !this.searchField.value.trim();
+	}
+
+	get navigating() {
+		return this.searchField.hasAttribute("aria-activedescendant");
 	}
 
 	get searchField() { // TODO: memoize, resetting cached value on blur?

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -113,7 +113,6 @@ export default class SimpleteSuggestions extends HTMLElement {
 		if(target) {
 			target.click(); // XXX: hacky?
 		}
-		this.render("");
 	}
 
 	onAbort(ev) {
@@ -134,15 +133,15 @@ export default class SimpleteSuggestions extends HTMLElement {
 		}
 	}
 
-	selectItem(node, preview) {
-		if(!preview) {
+	selectItem(node, navigating) {
+		if(!navigating) {
 			node = node.cloneNode(true); // prevents IE 11 from discarding child elements
 			this.render("");
 		}
 
 		let payload = {
 			id: node.id,
-			preview
+			navigating
 		};
 		let field = node.querySelector(this.fieldSelector);
 		if(field) {

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -113,6 +113,7 @@ export default class SimpleteSuggestions extends HTMLElement {
 		if(target) {
 			target.click(); // XXX: hacky?
 		}
+		this.render("");
 	}
 
 	onAbort(ev) {


### PR DESCRIPTION
Once thing that we noticed during the tests of this component was that it should be possible for the user to decide to ignore the options in the list and continue typing to complete their original intended search string.

This adds a case for when the user is navigating in the dropdown of
simplete results. If the user does not find a result that they are
interested in, they can continue typing and then their original input
will be restored and the simplete will be aborted. This is especially
necessary for assistive technologies because they will likely not be
able to inspect the results in the simplete list without inspecting each
one of them.

This also refactors the implementation of `this.navigating`. Instead of
using a variable that we have to explicitly set, we can check if the
`aria-activedescendant` attribute is set on the search field, because if
this is set, we know that the user is currently navigating within the
simplete dropdown. When the dropdown is toggled, the
`aria-activedescendant` attribute is always removed.

Note that this also slightly tweaks the `onConfirm` method within
SearchSuggestions which requires a review because I'm not completely
clear on how the onConfirm method should behave.