### PR TITLE
repaired bug with aria-selected attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "simplete",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "HTML-based autocompletion",
 	"author": "FND",
 	"license": "Apache-2.0",

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -88,7 +88,7 @@ export default class SimpleteSuggestions extends HTMLElement {
 			currentItem = next ? // eslint-disable-next-line indent
 					this.querySelector(selector) : selectLast(this, selector);
 		} else { // select adjacent item or wrap around
-			currentItem.removeAttribute("aria-selected");
+			currentItem.setAttribute("aria-selected", "false");
 
 			let items = find(this, selector);
 			let index = items.indexOf(currentItem);
@@ -107,7 +107,10 @@ export default class SimpleteSuggestions extends HTMLElement {
 	}
 
 	onConfirm(ev) {
-		let item = this.querySelector(`${this.itemSelector}[aria-selected]`);
+		let item = this.querySelector(`${this.itemSelector}[aria-selected=true]`);
+		if(!item) {
+			return;
+		}
 		let target = item.querySelector(this.fieldSelector) ||
 				item.querySelector(this.resultSelector);
 		if(target) {


### PR DESCRIPTION
This repairs a bug with the `aria-selected` attribute and the behavior of `onConfirm`. When cycling, the `aria-selected` attribute should be set to `aria-selected=false` instead of removed. Additionally, within the `onConfirm` event, we should select specifically for an attribute with `[aria-selected=true]`, not just `[aria-selected]`, because `[aria-selected]` will always select the first element in the list, not the element which is actually selected.

Note that this behavior was discovered because of some buggy behavior with the autocomplete. To reproduce the buggy behavior, execute the following behavior _without_ the changes introduced in this commit:

1. open the demo application and type in the "Mixed Content" search box
2. use the arrow keys to navigate through the list of options
3. delete all input from the search field and then input something else in the field
4. hit the enter key. This triggers the `simplete-confirm` event, which then finds the first element in the list with an `[aria-selected]` (which is always the first element in the list) and sends the confirm for that element.

The expected behavior is that the `onConfirm` event will only be successful if there is an attribute in the list which actually has the `[aria-selected=true]` element.